### PR TITLE
Support-for-mac-silicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .data/*
 checkpoint/*
 *.pyc
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.data/*
+checkpoint/*
+*.pyc

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+
+        {
+            "name": "Python: Train CycleGAN-Pix2Pix",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/CycleGAN-Pix2Pix/train.py",
+            "args": [
+            "--device", "mps",
+            "--dataroot", "${workspaceFolder}/.data/sar2opt",
+            "--name", "sar2opt_pix2pix",
+            "--model", "pix2pix",
+            "--direction", "AtoB",
+            "--dataset_mode", "unaligned",
+            "--serial_batches",
+            "--no_flip"
+            //"--save_latest_freq","100"
+            //"--load_size", "256",
+            //"--crop_size", "256",
+            //"--preprocess", "crop"
+            //"--display_winsize", "256"
+            ],
+            "console": "integratedTerminal",
+            "pythonPath": "/Users/adamloverro/projects/venv/sar2opt/bin/python"
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
     "configurations": [
 
         {
-            "name": "Python: Train CycleGAN-Pix2Pix",
+            "name": "Train CycleGAN-Pix2Pix",
             "type": "python",
             "request": "launch",
             "program": "${workspaceFolder}/CycleGAN-Pix2Pix/train.py",

--- a/CycleGAN-Pix2Pix/models/pix2pix_model.py
+++ b/CycleGAN-Pix2Pix/models/pix2pix_model.py
@@ -1,6 +1,7 @@
 import torch
 from .base_model import BaseModel
 from . import networks
+import os
 
 
 class Pix2PixModel(BaseModel):
@@ -54,11 +55,11 @@ class Pix2PixModel(BaseModel):
             self.model_names = ['G']
         # define networks (both generator and discriminator)
         self.netG = networks.define_G(opt.input_nc, opt.output_nc, opt.ngf, opt.netG, opt.norm,
-                                      not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids)
+                                      not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids, self.device)
 
         if self.isTrain:  # define a discriminator; conditional GANs need to take both input and output images; Therefore, #channels for D is input_nc + output_nc
             self.netD = networks.define_D(opt.input_nc + opt.output_nc, opt.ndf, opt.netD,
-                                          opt.n_layers_D, opt.norm, opt.init_type, opt.init_gain, self.gpu_ids)
+                                          opt.n_layers_D, opt.norm, opt.init_type, opt.init_gain, self.gpu_ids, self.device)
 
         if self.isTrain:
             # define loss functions
@@ -81,6 +82,8 @@ class Pix2PixModel(BaseModel):
         AtoB = self.opt.direction == 'AtoB'
         self.real_A = input['A' if AtoB else 'B'].to(self.device)
         self.real_B = input['B' if AtoB else 'A'].to(self.device)
+        self.real_A_filename = os.path.splitext(os.path.basename(input['A_paths' if AtoB else 'B_paths'][0]))[0]
+        self.real_B_filename = os.path.splitext(os.path.basename(input['B_paths' if AtoB else 'A_paths'][0]))[0]
         self.image_paths = input['A_paths' if AtoB else 'B_paths']
 
     def forward(self):

--- a/CycleGAN-Pix2Pix/options/base_options.py
+++ b/CycleGAN-Pix2Pix/options/base_options.py
@@ -23,10 +23,11 @@ class BaseOptions():
         parser.add_argument('--dataroot', required=True, help='path to images (should have subfolders trainA, trainB, valA, valB, etc)')
         parser.add_argument('--name', type=str, default='experiment_name', help='name of the experiment. It decides where to store samples and models')
         parser.add_argument('--gpu_ids', type=str, default='0', help='gpu ids: e.g. 0  0,1,2, 0,2. use -1 for CPU')
+        parser.add_argument('--device', type=str, default='cuda', choices=['cuda', 'mps'], help='choose which GPU device architecture to use: cuda or mps')
         
         # 这一句为了测FID-Epoch修改为绝对路径
-        parser.add_argument('--checkpoints_dir', type=str, default='/workspace/Image_translation_codes/pytorch-CycleGAN-and-pix2pix/checkpoint', help='models are saved here')
-        # parser.add_argument('--checkpoints_dir', type=str, default='./checkpoint', help='models are saved here')
+        #parser.add_argument('--checkpoints_dir', type=str, default='/workspace/Image_translation_codes/pytorch-CycleGAN-and-pix2pix/checkpoint', help='models are saved here')
+        parser.add_argument('--checkpoints_dir', type=str, default='./checkpoint', help='models are saved here')
         
         # model parameters
         parser.add_argument('--model', type=str, default='cycle_gan', help='chooses which model to use. [cycle_gan | pix2pix | test | colorization]')
@@ -137,8 +138,8 @@ class BaseOptions():
             id = int(str_id)
             if id >= 0:
                 opt.gpu_ids.append(id)
-        if len(opt.gpu_ids) > 0:
-            torch.cuda.set_device(opt.gpu_ids[0])
+        #if len(opt.gpu_ids) > 0:
+        #    torch.cuda.set_device(opt.gpu_ids[0])
 
         self.opt = opt
         return self.opt

--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ You can get the dataset from:
 - [Google Drive](https://drive.google.com/file/d/1XB9pWq-tVdxQsbVALxbYIF0Em90J4kkR/view?usp=sharing)  
 - [BaiduDisk](https://pan.baidu.com/s/1xQ1nc2aPFdJ99SI2upl5Tg) (hy8d)
 
+At least for pix2pix training, the folder arrangement of the dataset, as downloaded from the google site above, is a so-called 'unaligned' dataset, i.e. the A B images are divided into sepearate directories:
+As downloaded:
+```
+sar2opt/
+├── trainA/
+├── trainB/
+├── testA/
+└── testB/
+```
+Therefore, to use this dataset, use the --dataset_mode=unaligned option flag for training and test.
 
 ## Image-to-image translation results on __SAR2Opt dataset__
 Here are some translated results on our SAR2Opt dataset with well-known GAN-based methods, which have been included in our GRSL paper.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+torch
+torchvision
+numpy
+pillow
+dominate
+visdom
+scipy


### PR DESCRIPTION
# Two major updates to the baseline code:

## Support for the mac silicon 'MPS' device

The original software assumed (inconsistently) that a CUDA device was prefferred; The updates here enable the user to force use of CPU or MPS devices, the later of which is used by macos silicon M1 or later.

## Addition of a VSCode debug configuration

Includes a vscode debug configuraiton that uses a functional set of input options to train the pix2pix model. The README as it is today is misleading with respect to the proper or even functional set of inputs required for training.